### PR TITLE
Bump version to 2.4.11

### DIFF
--- a/OpenCV.nuspec
+++ b/OpenCV.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>OpenCV</id>
     <title>OpenCV</title>
-    <version>2.4.9.20140518</version>
+    <version>2.4.11.20150226</version>
     <authors>OpenCV</authors>
     <owners>Yann ROBIN</owners>
     <summary>OpenCV (full setup)</summary>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+install:
+  - cinst OpenCV
+
+build_script:
+  - ps: Test-Path c:\OpenCV2411\include\opencv\cv.h

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,10 +1,10 @@
 ﻿#NOTE: Please remove any commented lines to tidy up prior to releasing the package, including this one
 
 $packageName = 'OpenCV' # arbitrary name for the package, used in messages
+$version = "2.4.11"
 $binRoot = "$env:systemdrive\"
-$installDir = Join-Path $binRoot 'OpenCV249'
-$url = 'http://downloads.sourceforge.net/project/opencvlibrary/opencv-win/2.4.9/opencv-2.4.9.exe'
-#$url = 'http://downloads.sourceforge.net/project/opencvlibrary/opencv-win/2.4.0/OpenCV-2.4.0.exe' # download url
+$installDir = Join-Path $binRoot 'OpenCV2411'
+$url = 'http://downloads.sourceforge.net/project/opencvlibrary/opencv-win/${version}/opencv-${version}.exe'
 $url64 = $url # 64bit URL here or just use the same as $url
 $validExitCodes = @(0) #please insert other valid exit codes here, exit codes for ms http://msdn.microsoft.com/en-us/library/aa368542(VS.85).aspx
 


### PR DESCRIPTION
This updates to the latest OpenCV version.

Note that I have not tried to run this myself using cinst... because I don't know how exactly. However the exe is downloadable from the given URL at least...
